### PR TITLE
Corrige warnings de compilação

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -57,7 +57,7 @@ Image readPPM(char *filepath)
 	}
 
 	// reading maximum RGB value
-	if (fscanf(image, "%u", &img.maxRGB) != 1)
+	if (fscanf(image, "%hhu", &img.maxRGB) != 1)
 	{
 		fprintf(stderr, "\tInvalid maximum RBG value.\n");
 	}

--- a/src/menu.c
+++ b/src/menu.c
@@ -35,7 +35,7 @@ void printMenu()
  * (for instance, EXIT = 0, READDPPM = 1 and so on)
  */
 
-typedef enum Options
+enum Options
 {
 	EXIT,
 	GRAYSCALE,
@@ -46,7 +46,7 @@ typedef enum Options
 	ROTATE,
 	ZOOM,
 	EXTRAS
-} Options;
+};
 
 /* this guy here will receive the user's entered number and 
  * will judge whether the choice is valid or not according 
@@ -56,7 +56,7 @@ typedef enum Options
 void menuOptions()
 {
 	int aux = 1, q, choice, intensity;
-	Options option;
+	int option;
 
 	char *filepath;
 	Image image  = readPPM(filepath);


### PR DESCRIPTION
"Tirei o "typedef" do enum, ja q realmente n precisava, ele está sendo usado do jeito ~classico dos enums. Ai em vez de criar uma variavel do tipo Options eu criei so um int msm. Ai o enum parece q funciona tipo um define. Onde tem EXIT é visto como 0 pelo compilador!"